### PR TITLE
Support code blocks used in lists, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-code-buttons",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Add copy buttons to code snippets",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = function gatsbyRemarkCodeButtons(
     toasterDuration: customToasterDuration
   }
 ) {
-  visit(markdownAST, 'code', (node, index) => {
+  visit(markdownAST, 'code', (node, index, parent) => {
     const [language, params] = (node.lang || '').split(':');
     const actions = qs.parse(params);
     const { clipboard } = actions;
@@ -40,7 +40,7 @@ module.exports = function gatsbyRemarkCodeButtons(
       const toasterDuration = (customToasterDuration ? customToasterDuration : 3500);
       const toasterId = (toasterText ? Math.random() * 100 ** 10 : '');
 
-      let code = markdownAST.children[index].value;
+      let code = parent.children[index].value;
       code = code.replace(/"/gm, '&quot;').replace(/`/gm, '\\`').replace(/\$/gm, '\\$');
 
       const buttonNode = {
@@ -65,7 +65,7 @@ module.exports = function gatsbyRemarkCodeButtons(
             `.trim()
       };
 
-      markdownAST.children.splice(index, 0, buttonNode);
+      parent.children.splice(index, 0, buttonNode);
       actions['clipboard'] = 'false';
     }
 


### PR DESCRIPTION
Fixes #14.

Updates the implementation of the `visit` handler to use the actual `parent` instead of assuming that `markdownAST` is the parent.